### PR TITLE
Revert "Bump xunit.runner.visualstudio from 2.4.0 to 2.4.5"

### DIFF
--- a/test/Eryph.ClientRuntime.Configuration.Tests/Eryph.ClientRuntime.Configuration.Tests.csproj
+++ b/test/Eryph.ClientRuntime.Configuration.Tests/Eryph.ClientRuntime.Configuration.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Reverts eryph-org/dotnet-clientruntime#9