### PR TITLE
Bugfix: Get-EryphClientCredentials fails

### DIFF
--- a/src/Eryph.ClientRuntime.Powershell/PowershellEnvironment.cs
+++ b/src/Eryph.ClientRuntime.Powershell/PowershellEnvironment.cs
@@ -1,4 +1,5 @@
-﻿using System.Management.Automation;
+﻿using System.Linq;
+using System.Management.Automation;
 using Eryph.IdentityModel.Clients;
 
 namespace Eryph.ClientRuntime.Powershell
@@ -17,12 +18,13 @@ namespace Eryph.ClientRuntime.Powershell
             return _sessionState.Path.CurrentFileSystemLocation.Path;
         }
 
-        //public override bool IsProcessRunning(string processName, int processId)
-        //{
-        //   return _sessionState.InvokeCommand.InvokeScript(
-        //        $"Get-Process {processName} -ErrorAction SilentlyContinue | where Id -eq {processId} | Select -First 1").Any();
-
-        //}
+        public override bool IsProcessRunning(string processName, int processId)
+        {
+            var scriptBlock = _sessionState.InvokeCommand.NewScriptBlock(
+                $"Get-Process {processName} -ErrorAction SilentlyContinue | where Id -eq {processId} | Select -First 1");
+            var isRunning = scriptBlock.Invoke().Any();
+            return isRunning;
+        }
 
         //public override bool IsWindowsAdminUser
         //{


### PR DESCRIPTION
For non admin users and zero configuration the credential lookup always fails due to permission errors while looking up running processes.
Restored powershell method to lookup processes.