### PR TITLE
Add Get-EryphAccessToken CmdLet

### DIFF
--- a/build/Eryph.ClientRuntime.Configuration.psd1
+++ b/build/Eryph.ClientRuntime.Configuration.psd1
@@ -72,7 +72,7 @@ ClrVersion = '4.0'
 FunctionsToExport = @()
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
-CmdletsToExport = @("Add-EryphClientConfiguration","Get-EryphClientConfiguration", "Set-EryphClientConfiguration", "Remove-EryphClientConfiguration", "New-EryphClientCredentials", "Get-EryphClientCredentials", "Set-EryphConfigurationStore")
+CmdletsToExport = @("Add-EryphClientConfiguration", "Get-EryphAccessToken", "Get-EryphClientConfiguration", "Set-EryphClientConfiguration", "Remove-EryphClientConfiguration", "New-EryphClientCredentials", "Get-EryphClientCredentials", "Set-EryphConfigurationStore")
 
 # Variables to export from this module
 VariablesToExport = '*'

--- a/src/Eryph.ClientRuntime.Configuration.Commands/GetEryphAccessToken.cs
+++ b/src/Eryph.ClientRuntime.Configuration.Commands/GetEryphAccessToken.cs
@@ -1,0 +1,75 @@
+﻿using Eryph.ClientRuntime.Powershell;
+using Eryph.IdentityModel.Clients;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using System.Security;
+using System.Text;
+
+namespace Eryph.ClientRuntime.Configuration
+{
+    [Cmdlet(VerbsCommon.Get, "EryphAccessToken")]
+    [OutputType(typeof(AccessTokenResult))]
+    public class GetEryphAccessToken : EryphCmdLet
+    {
+        [Parameter(HelpMessage = "The OAuth scopes to request for the access token.")]
+        public string[] Scopes { get; set; }
+
+        [Parameter(HelpMessage = "Return only the access token as plain string.")]
+        public SwitchParameter AsPlainText { get; set; }
+
+        protected override void ProcessRecord()
+        {
+            var clientCredentials = GetClientCredentials();
+            var response = clientCredentials.GetAccessToken(Scopes).GetAwaiter().GetResult();
+
+            if (AsPlainText.ToBool())
+            {
+                WriteObject(response.AccessToken);
+            }
+            else
+            {
+                WriteObject(new AccessTokenResult(
+                    response,
+                    clientCredentials.IdentityProvider,
+                    clientCredentials.Configuration));
+            }
+        }
+
+        public class AccessTokenResult
+        {
+            public AccessTokenResult(
+                AccessTokenResponse response,
+                Uri identityEndpoint,
+                string configuration)
+            {
+                var secureString = new SecureString();
+                foreach (var c in response.AccessToken)
+                {
+                    secureString.AppendChar(c);
+                }
+                secureString.MakeReadOnly();
+                AccessToken = secureString;
+                Scopes = response.Scopes.ToArray();
+                ExpiresOn = response.ExpiresOn?.LocalDateTime;
+                IdentityEndpoint = identityEndpoint;
+                Configuration = configuration;
+            }
+
+            // Do not remove properties without checking the output in Powershell.
+            // With 4 or fewer properties, Powershell switches into table mode which
+            // makes the result unreadable.
+
+            public SecureString AccessToken { get; private set; }
+
+            public string[] Scopes { get; private set; }
+
+            public DateTime? ExpiresOn { get; private set; }
+
+            public Uri IdentityEndpoint { get; private set; }
+
+            public string Configuration { get; private set; }
+        }
+    }
+}


### PR DESCRIPTION
Add the `Get-EryphAccessToken` CmdLet which can be used to fetch an access token for the eryph API.

This CmdLet is a convenience feature for users who would like to work directly with the REST API.