### PR TITLE
Add support for problem details

### DIFF
--- a/build/Eryph.ClientRuntime.Configuration.psd1
+++ b/build/Eryph.ClientRuntime.Configuration.psd1
@@ -42,7 +42,7 @@ PowerShellVersion = '5.1'
 # PowerShellHostVersion = ''
 
 # Minimum version of Microsoft .NET Framework required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
-DotNetFrameworkVersion = '4.6.1'
+DotNetFrameworkVersion = '4.6.2'
 
 # Minimum version of the common language runtime (CLR) required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
 ClrVersion = '4.0'

--- a/build/build-cmdlet.ps1
+++ b/build/build-cmdlet.ps1
@@ -34,8 +34,8 @@ mkdir coreclr | Out-Null
 mkdir desktop | Out-Null
 
 cp $rootDir\build\${cmdletName}* .
-cp $rootDir\src\${cmdletName}.Commands\bin\${Configuration}\netcoreapp3.1\* coreclr -Exclude $excludedFiles -Recurse
-cp $rootDir\src\${cmdletName}.Commands\bin\${Configuration}\net461\* desktop  -Exclude $excludedFiles  -Recurse
+cp $rootDir\src\${cmdletName}.Commands\bin\${Configuration}\net6.0\* coreclr -Exclude $excludedFiles -Recurse
+cp $rootDir\src\${cmdletName}.Commands\bin\${Configuration}\net462\* desktop  -Exclude $excludedFiles  -Recurse
 
 $config = gc "${cmdletName}.psd1" -Raw
 $config = $config.Replace("ModuleVersion = '0.1'", "ModuleVersion = '${Env:GITVERSION_MajorMinorPatch}'");

--- a/src/Eryph.ClientRuntime.Configuration.Commands/Eryph.ClientRuntime.Configuration.Commands.csproj
+++ b/src/Eryph.ClientRuntime.Configuration.Commands/Eryph.ClientRuntime.Configuration.Commands.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net462</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <RootNamespace>Eryph.ClientRuntime.Configuration</RootNamespace>
     <IsPackable>false</IsPackable>

--- a/src/Eryph.ClientRuntime.Configuration.Commands/Eryph.ClientRuntime.Configuration.Commands.csproj
+++ b/src/Eryph.ClientRuntime.Configuration.Commands/Eryph.ClientRuntime.Configuration.Commands.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <RootNamespace>Eryph.ClientRuntime.Configuration</RootNamespace>
     <IsPackable>false</IsPackable>

--- a/src/Eryph.ClientRuntime.Configuration.Commands/Properties/launchSettings.json
+++ b/src/Eryph.ClientRuntime.Configuration.Commands/Properties/launchSettings.json
@@ -1,0 +1,17 @@
+{
+  "profiles": {
+    "Eryph.ClientRuntime.Configuration.Commands": {
+      "commandName": "Project"
+    },
+    "Run in Powershell": {
+      "commandName": "Executable",
+      "executablePath": "Powershell.exe",
+      "commandLineArgs": "-NoProfile -NoExit -Command \"Import-Module $(TargetPath)\""
+    },
+    "Run in Powershell Core": {
+      "commandName": "Executable",
+      "executablePath": "pwsh.exe",
+      "commandLineArgs": "-NoProfile -NoExit -Command \"Import-Module $(TargetPath)\""
+    }
+  }
+}

--- a/src/Eryph.ClientRuntime/Eryph.ClientRuntime.csproj
+++ b/src/Eryph.ClientRuntime/Eryph.ClientRuntime.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.34.0" />
+    <PackageReference Include="Azure.Core" Version="1.39.0" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.12.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Eryph.ClientRuntime/Eryph.ClientRuntime.csproj
+++ b/src/Eryph.ClientRuntime/Eryph.ClientRuntime.csproj
@@ -30,6 +30,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="System.Text.Json" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Eryph.ClientRuntime/Eryph.ClientRuntime.csproj
+++ b/src/Eryph.ClientRuntime/Eryph.ClientRuntime.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>12</LangVersion>
     <IncludeGeneratorSharedCode>true</IncludeGeneratorSharedCode>
     <RestoreAdditionalProjectSources>https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json</RestoreAdditionalProjectSources>
   </PropertyGroup>

--- a/src/Eryph.ClientRuntime/EryphRequestFailedDetailsParser.cs
+++ b/src/Eryph.ClientRuntime/EryphRequestFailedDetailsParser.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Azure;
+using Azure.Core;
+
+namespace Eryph.ClientRuntime;
+
+public class EryphRequestFailedDetailsParser : RequestFailedDetailsParser
+{
+    public override bool TryParse(
+        Response response,
+        out ResponseError? error,
+        out IDictionary<string, string>? data)
+    {
+        error = null;
+        data = null;
+
+        if (!response.Headers.TryGetValue("Content-Type", out var contentType))
+            return false;
+
+        if (!contentType.StartsWith("application/problem+json", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        if (!TryDeserializeProblemDetails(response.Content, out var problemDetails)
+            || problemDetails is null)
+            return false;
+
+        data = CreateData(problemDetails);
+        var message = CreateMessage(problemDetails);
+        error = new ResponseError(null, message);
+
+        return true;
+    }
+
+    private static IDictionary<string, string>? CreateData(ProblemDetails problemDetails)
+    {
+        if (problemDetails.AdditionalProperties is not { Count: > 0 })
+            return null;
+
+        if (!problemDetails.AdditionalProperties.TryGetPropertyValue("traceId", out var node)
+            || node is not JsonValue jsonValue
+            || !jsonValue.TryGetValue(out string traceId))
+            return null;
+        
+        return new Dictionary<string, string>
+        {
+            ["traceId"] = traceId,
+        };
+    }
+
+    private static string CreateMessage(ProblemDetails problemDetails)
+    {
+        var builder = new StringBuilder();
+        var message = !string.IsNullOrWhiteSpace(problemDetails.Title)
+            ? problemDetails.Title
+            : "The request has failed";
+
+        builder.AppendLine(message);
+
+        if (!string.IsNullOrWhiteSpace(problemDetails.Detail))
+            builder.AppendLine(problemDetails.Detail);
+
+        if (problemDetails.Errors is not { Count: > 0 })
+            return builder.ToString();
+        
+        builder.AppendLine("The request has the following errors:");
+        foreach (var kp in problemDetails.Errors.OrderBy(kp => kp.Key))
+        {
+            builder.AppendLine($"- {kp.Key}");
+            foreach (var value in kp.Value)
+                builder.AppendLine($"  {value}");
+        }
+
+        return builder.ToString();
+    }
+
+    private static bool TryDeserializeProblemDetails(
+        BinaryData content,
+        out ProblemDetails? problemDetails)
+    {
+        try
+        {
+            problemDetails = JsonSerializer.Deserialize<ProblemDetails>(
+                content,
+                new JsonSerializerOptions()
+                {
+                    PropertyNameCaseInsensitive = true,
+                });
+            return true;
+        }
+        catch (JsonException)
+        {
+            problemDetails = null;
+            return false;
+        }
+    }
+}

--- a/src/Eryph.ClientRuntime/ProblemDetails.cs
+++ b/src/Eryph.ClientRuntime/ProblemDetails.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace Eryph.ClientRuntime;
+
+internal class ProblemDetails
+{
+    public string? Type { get; set; }
+    
+    public string? Title { get; set; }
+
+    public int? Status { get; set; }
+
+    public string? Detail { get; set; }
+
+    public string? Instance { get; set; }
+
+    public IDictionary<string, string[]>? Errors { get; set; }
+
+    [JsonExtensionDataAttribute]
+    public JsonObject? AdditionalProperties { get; set; }
+}

--- a/test/Eryph.ClientRuntime.Configuration.Tests/Eryph.ClientRuntime.Configuration.Tests.csproj
+++ b/test/Eryph.ClientRuntime.Configuration.Tests/Eryph.ClientRuntime.Configuration.Tests.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net461</TargetFrameworks>
-
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Eryph.ClientRuntime.Configuration.Tests/Eryph.ClientRuntime.Configuration.Tests.csproj
+++ b/test/Eryph.ClientRuntime.Configuration.Tests/Eryph.ClientRuntime.Configuration.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net462</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Eryph.ClientRuntime.Configuration.Tests/Eryph.ClientRuntime.Configuration.Tests.csproj
+++ b/test/Eryph.ClientRuntime.Configuration.Tests/Eryph.ClientRuntime.Configuration.Tests.csproj
@@ -6,11 +6,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This PR introduces some shared code for properly processing error responses which contain problem details
according to RFC 9457.

Additionally, some general maintenance is performed:
- Bump the target frameworks as some older versions are end-of-life
- Update the Autorest dependencies to the latest version